### PR TITLE
migrate blockClient to dataClient

### DIFF
--- a/src/components/tokens/TopTokenMovers.tsx
+++ b/src/components/tokens/TopTokenMovers.tsx
@@ -37,7 +37,7 @@ export const ScrollableRow = styled.div`
 
 const DataCard = ({ tokenData }: { tokenData: TokenData }) => {
   return (
-    <CardWrapper to={'tokens/' + tokenData.address}>
+    <CardWrapper to={tokenData.address}>
       <GreyCard padding="16px">
         <RowFixed>
           <CurrencyLogo address={tokenData.address} size="32px" />

--- a/src/constants/networks.ts
+++ b/src/constants/networks.ts
@@ -132,12 +132,12 @@ export const AvalancheNetworkInfo: NetworkInfo = {
 
 export const SUPPORTED_NETWORK_VERSIONS: NetworkInfo[] = [
   ClassicNetworkInfo,
-  EthereumNetworkInfo,
-  PolygonNetworkInfo,
-  OptimismNetworkInfo,
-  ArbitrumNetworkInfo,
-  CeloNetworkInfo,
-  BNBNetworkInfo,
-  BaseNetworkInfo,
-  AvalancheNetworkInfo,
+  // EthereumNetworkInfo,
+  // PolygonNetworkInfo,
+  // OptimismNetworkInfo,
+  // ArbitrumNetworkInfo,
+  // CeloNetworkInfo,
+  // BNBNetworkInfo,
+  // BaseNetworkInfo,
+  // AvalancheNetworkInfo,
 ]

--- a/src/data/protocol/overview.ts
+++ b/src/data/protocol/overview.ts
@@ -31,25 +31,21 @@ interface GlobalResponse {
   }[]
 }
 
-export function useFetchProtocolData(
-  dataClientOverride?: ApolloClient<NormalizedCacheObject>,
-  blockClientOverride?: ApolloClient<NormalizedCacheObject>,
-): {
+export function useFetchProtocolData(dataClientOverride?: ApolloClient<NormalizedCacheObject>): {
   loading: boolean
   error: boolean
   data: ProtocolData | undefined
 } {
   // get appropriate clients if override needed
-  const { dataClient, blockClient } = useClients()
+  const { dataClient } = useClients()
   const activeDataClient = dataClientOverride ?? dataClient
-  const activeBlockClient = blockClientOverride ?? blockClient
 
   // Aggregate TVL in inaccurate pools. Offset Uniswap aggregate TVL by this amount.
   const tvlOffset = useTVLOffset()
 
   // get blocks from historic timestamps
   const [t24, t48] = useDeltaTimestamps()
-  const { blocks, error: blockError } = useBlocksFromTimestamps([t24, t48], activeBlockClient)
+  const { blocks, error: blockError } = useBlocksFromTimestamps([t24, t48], activeDataClient)
   const [block24, block48] = blocks ?? []
 
   // fetch all data

--- a/src/data/tokens/priceData.ts
+++ b/src/data/tokens/priceData.ts
@@ -65,7 +65,6 @@ export async function fetchTokenPriceData(
   interval: number,
   startTimestamp: number,
   dataClient: ApolloClient<NormalizedCacheObject>,
-  blockClient: ApolloClient<NormalizedCacheObject>,
 ): Promise<{
   data: PriceChartEntry[]
   error: boolean
@@ -100,7 +99,7 @@ export async function fetchTokenPriceData(
     }
 
     // fetch blocks based on timestamp
-    const blocks = await getBlocksFromTimestamps(timestamps, blockClient, 500)
+    const blocks = await getBlocksFromTimestamps(timestamps, dataClient, 500)
     if (!blocks || blocks.length === 0) {
       console.log('Error fetching blocks')
       return {

--- a/src/hooks/useBlocksFromTimestamps.ts
+++ b/src/hooks/useBlocksFromTimestamps.ts
@@ -8,10 +8,8 @@ import { ApolloClient, NormalizedCacheObject } from '@apollo/client'
 export const GET_BLOCKS = (timestamps: string[]) => {
   let queryString = 'query blocks {'
   queryString += timestamps.map((timestamp) => {
-    return `t${timestamp}:blocks(first: 1, orderBy: timestamp, orderDirection: desc, where: { timestamp_gt: ${timestamp}, timestamp_lt: ${
-      timestamp + 600
-    } }) {
-        number
+    return `t${timestamp}:transactions(first: 1, orderBy: timestamp, orderDirection: desc, where: { timestamp_lte: ${timestamp} }) {
+        blockNumber
       }`
   })
   queryString += '}'
@@ -38,8 +36,8 @@ export function useBlocksFromTimestamps(
   const [blocks, setBlocks] = useState<any>()
   const [error, setError] = useState(false)
 
-  const { blockClient } = useClients()
-  const activeBlockClient = blockClientOverride ?? blockClient
+  const { dataClient } = useClients()
+  const activeBlockClient = blockClientOverride ?? dataClient
 
   // derive blocks based on active network
   const networkBlocks = blocks?.[activeNetwork.id]
@@ -64,7 +62,7 @@ export function useBlocksFromTimestamps(
       const formatted = []
       for (const t in networkBlocks) {
         if (networkBlocks[t].length > 0) {
-          const number = networkBlocks[t][0]['number']
+          const number = networkBlocks[t][0]['blockNumber']
           const deploymentBlock = START_BLOCKS[activeNetwork.id]
           const adjustedNumber = number > deploymentBlock ? number : deploymentBlock
 
@@ -108,7 +106,7 @@ export async function getBlocksFromTimestamps(
       if (fetchedData[t].length > 0) {
         blocks.push({
           timestamp: t.split('t')[1],
-          number: fetchedData[t][0]['number'],
+          number: fetchedData[t][0]['blockNumber'],
         })
       }
     }

--- a/src/state/tokens/hooks.ts
+++ b/src/state/tokens/hooks.ts
@@ -182,13 +182,7 @@ export function useTokenPriceData(
 
   useEffect(() => {
     async function fetch() {
-      const { data, error: fetchingError } = await fetchTokenPriceData(
-        address,
-        interval,
-        startTimestamp,
-        dataClient,
-        blockClient,
-      )
+      const { data, error: fetchingError } = await fetchTokenPriceData(address, interval, startTimestamp, dataClient)
       if (data) {
         dispatch(
           updatePriceData({


### PR DESCRIPTION
# Before 

![Screenshot 2024-07-02 at 11 24 53 AM](https://github.com/etcswap/v3-info/assets/19412160/1e25b9a2-eae6-4dea-bc38-2268281d2f8a)

# After

![Screenshot 2024-07-02 at 12 05 30 PM](https://github.com/etcswap/v3-info/assets/19412160/52ab2d6e-e40c-459d-b685-5e49d8b76380)

# Summary

- Info requires 2 subgraphs
    - dataClient
    - blockClient
- etcswap only has dataClient: [graph.etcswap.org](https://graph.etcswap.org/subgraphs/name/etcswap-v3/graphql)
- adding a blockClient subgraph costs $ and is unnecessary
- solution: migrate `useBlocksFromTimestamps.ts` from blockClient to dataClient
- note a modified graphql [query](https://github.com/etcswap/v3-info/compare/etcswap...etcswap:v3-info:dataClient-migration?expand=1#diff-89a6fc05be3faf9cf022edce671f14c708c5f10a91ba79a8f371f4ef3839b8fbR11)
- *Conclusion: all queries are done through 1 client (dataClient)*
