### PR TITLE
change Volume 24H to Volume

### DIFF
--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -198,7 +198,7 @@ export default function Home() {
                 }
                 topLeft={
                   <AutoColumn $gap="4px">
-                    <TYPE.mediumHeader fontSize="16px">Volume 24H</TYPE.mediumHeader>
+                    <TYPE.mediumHeader fontSize="16px">Volume</TYPE.mediumHeader>
                     <TYPE.largeHeader fontSize="32px">
                       <MonoSpace> {formatDollarAmount(volumeHover, 2)}</MonoSpace>
                     </TYPE.largeHeader>


### PR DESCRIPTION
`Volume 24H` is confusing because the graph can show different ranges for D W M

![Screenshot 2024-07-22 at 2 10 26 PM](https://github.com/user-attachments/assets/c717ac9b-65b2-4bea-a625-4ecd0575fb52)
